### PR TITLE
Update URLs for homepage for Issue #48

### DIFF
--- a/components/StaryURL/StaryURL.jsx
+++ b/components/StaryURL/StaryURL.jsx
@@ -1,0 +1,7 @@
+const StaryURL = ({ title, link }) => (
+    <>
+        ✨ <a href={link}> {title} </a>
+    </>
+)
+
+export default StaryURL

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,6 +2,7 @@ import Head from 'next/head'
 import Image from 'next/image'
 import styles from '../styles/Home.module.css'
 import Card from '../components/Card/Card'
+import StaryURL from '../components/StaryURL/StaryURL'
 import { groups } from '../utils/config'
 
 export default function Home() {
@@ -23,7 +24,13 @@ export default function Home() {
           <p>
             Our alliance comprises the following groups:<br></br>
             <b style={{ color: '#358aca' }}>
-              ✨ SWFL Coders ✨ SWFL Data ✨ SWFL Sec ✨ Python SWFL ✨ VR & AR of Southwest Florida ✨
+            <StaryURL title="SWFL Coders" link="https://www.meetup.com/swfl-coders/" />
+            <StaryURL title="SWFL Sec" link="https://www.meetup.com/SWFLSec-Southwest-Florida-Infosec-Meetup/" />
+            <StaryURL title="Python SWFL" link="https://www.meetup.com/pythonswfl/" />
+            <StaryURL title="VR & AR of Southwest Florida" link="https://www.meetup.com/vrarswfl/" />
+            <StaryURL title="SWFL Hackerspace" link="https://www.meetup.com/swfl-hackerspace/" />
+            <StaryURL title="SWFL Tech Nights" link="https://www.meetup.com/swfltechnights/" />
+            <StaryURL title="Music Producers of SWFL" link="https://www.facebook.com/musicproducers.swfl" />
             </b>
           </p>
           <p>


### PR DESCRIPTION
Updated the URLs as requested in issue #48 . Below is the before and after images with the URL updates:

Before:
![image](https://github.com/user-attachments/assets/ceb1805a-e328-4b4b-a4f3-2a1f2b6f3e78)

After:
![image](https://github.com/user-attachments/assets/ab595bf1-4e8e-433c-97a4-1b5b0192593e)

