### PR TITLE
  Add drop-shadow to social media icons

### DIFF
--- a/components/Card/Card.jsx
+++ b/components/Card/Card.jsx
@@ -14,12 +14,12 @@ const Card = ({ facebookLink, githubLink, groupName, groupLink, groupDescription
       <br />
       <p>{meetingDate}</p>
       <br />
-      <SocialIcon target="_blank" url={groupLink} />
-      {facebookLink && <SocialIcon className="ml-2" target="_blank" url={facebookLink} />}
-      {instagramLink && <SocialIcon className="ml-2" target="_blank" url={instagramLink} />}
-      {xLink && <SocialIcon className="ml-2" target="_blank" url={xLink} />}
-      {linkedinLink && <SocialIcon className="ml-2" target="_blank" url={linkedinLink} />}
-      {githubLink && <SocialIcon className="ml-2" target="_blank" url={githubLink} />}
+      <SocialIcon className="hover:drop-shadow-[0_2px_7px_rgba(0,0,0,0.5)]" target="_blank" url={groupLink} />
+      {facebookLink && <SocialIcon className="ml-2 hover:drop-shadow-[0_2px_7px_rgba(0,0,0,0.5)]" target="_blank" url={facebookLink} />}
+      {instagramLink && <SocialIcon className="ml-2 hover:drop-shadow-[0_2px_7px_rgba(0,0,0,0.5)]" target="_blank" url={instagramLink} />}
+      {xLink && <SocialIcon className="ml-2 hover:drop-shadow-[0_2px_7px_rgba(0,0,0,0.5)]" target="_blank" url={xLink} />}
+      {linkedinLink && <SocialIcon className="ml-2 hover:drop-shadow-[0_2px_7px_rgba(0,0,0,0.5)]" target="_blank" url={linkedinLink} />}
+      {githubLink && <SocialIcon className="ml-2 hover:drop-shadow-[0_2px_7px_rgba(0,0,0,0.5)]" target="_blank" url={githubLink} />}
       <br />
     </a>
   )


### PR DESCRIPTION
For issue #82 :

 I added a drop-shadow to the hover state of all the social media icons associated with each tech-alliance group:

![shadow](https://github.com/user-attachments/assets/fda87c40-50a0-434d-b4e1-6c7636cfc25d)
