### PR TITLE
Removes IG logo

### DIFF
--- a/components/Footer/Footer.jsx
+++ b/components/Footer/Footer.jsx
@@ -27,11 +27,6 @@ const Footer = () => {
           </a>
         </div>
         <div className={styles.logos}>
-          <a>
-            <Image src="/images/socials/ig-icon.png" alt="Instagram Logo" width={40} height={40} />
-          </a>
-        </div>
-        <div className={styles.logos}>
           <a href="https://www.youtube.com/@techallianceswfl" target="_blank" rel="noreferrer">
             <Image src="/images/socials/yt-icon.png" alt="Youtube Logo" width={40} height={40} />
           </a>


### PR DESCRIPTION
This part of a merge conflict and I forgot to remove the logo for Instagram.

Should look like this:
![Screenshot 2024-11-19 at 12 20 07 AM](https://github.com/user-attachments/assets/d19fd79d-a932-45cd-9c2c-692a3d1fa12d)
