### PR TITLE
Updates Music Makers broken links

### DIFF
--- a/components/Card/Card.jsx
+++ b/components/Card/Card.jsx
@@ -25,7 +25,9 @@ const Card = ({
       <CardDescription groupDescription={groupDescription} />
       <p className="text-base leading-normal md:text-lg">{meetingDate}</p>
       <div className="grid justify-start grid-flow-col-dense">
-        <SocialIcon style={{ height: 45, width: 45 }} target="_blank" url={groupLink} />
+        {groupLink && (
+          <SocialIcon style={{ height: 45, width: 45 }} target="_blank" url={groupLink} />
+        )}
         {facebookLink && (
           <SocialIcon style={{ height: 45, width: 45 }} className="ml-2" target="_blank" url={facebookLink} />
         )}

--- a/components/Header/Navigation.jsx
+++ b/components/Header/Navigation.jsx
@@ -15,7 +15,7 @@ const navigation = [
       { name: 'SWFLSec', href: 'https://www.meetup.com/SWFLSec-Southwest-Florida-Infosec-Meetup/' },
       { name: 'Python SWFL', href: 'https://www.meetup.com/pythonswfl/' },
       { name: 'SWFL Hackerspace', href: 'https://www.meetup.com/swfl-hackerspace/' },
-      { name: 'Music Makers SWFL', href: 'https://www.meetup.com/music-makers-of-southwest-florida/' },
+      { name: 'Music Makers SWFL', href: 'https://www.facebook.com/musicmakers.swfl' },
       { name: 'AR & VR SWFL', href: 'https://www.meetup.com/vrarswfl/' },
     ],
   },

--- a/pages/api/meetup.js
+++ b/pages/api/meetup.js
@@ -7,7 +7,6 @@ export default function Meetups() {
   const [meetups, setMeetups] = useState(null)
   const meetupUrls = [
     "https://api.meetup.com/SWFL-Coders/events",
-    "https://api.meetup.com/music-makers-of-southwest-florida/",
     "https://api.meetup.com/pythonswfl",
     "https://api.meetup.com/SWFL-Coders/events",
     "https://api.meetup.com/swfl-hackerspace",

--- a/pages/index.js
+++ b/pages/index.js
@@ -31,7 +31,7 @@ export default function Home() {
           <p className="mb-4">
             <b style={{ color: '#358aca' }}>
               <StaryURL title="SWFL Sec" link="https://www.meetup.com/SWFLSec-Southwest-Florida-Infosec-Meetup/" />
-              <StaryURL title="Music Makers of SWFL" link="https://www.meetup.com/music-makers-of-southwest-florida/" />
+              <StaryURL title="Music Makers of SWFL" link="https://www.facebook.com/musicmakers.swfl/" />
               <StaryURL title="VR & AR of Southwest Florida" link="https://www.meetup.com/vrarswfl/" />
               <StaryURL title="SWFL Coders" link="https://www.meetup.com/swfl-coders/" />
               <StaryURL title="Python SWFL" link="https://www.meetup.com/pythonswfl/" />

--- a/utils/config.js
+++ b/utils/config.js
@@ -5,7 +5,6 @@ export const groups = [
     groupDescription:
       "Welcome to the Music Makers of Southwest Florida, where the beats of the Gulf meet a community of passionate music makers, artists, creators, and enthusiasts! Our group is dedicated to bringing together individuals with varying levels of experience, from seasoned producers to those eager to learn the art of creating music. Our main goal is to provide a platform for music enthusiasts to connect, collaborate, and enhance their music production skills. Whether you're already experienced in the field or just starting your journey, our doors are wide open for you to join, learn, and grow alongside fellow enthusiasts.",
     meetingDate: 'Meets the first Tuesday of odd-numbered months',
-    groupLink: 'https://www.meetup.com/music-makers-of-southwest-florida/',
     facebookLink: 'https://www.facebook.com/musicmakers.swfl',
     instagramLink: 'https://www.instagram.com/musicmakers_swfl/',
   },


### PR DESCRIPTION
## Problem

Music Makers not longer has a Meetup page

## Solution

Remove all links related to Meetup for Music Makers

## Visuals
<img width="922" height="307" alt="Screenshot 2026-03-31 at 2 19 28 PM" src="https://github.com/user-attachments/assets/bbba4134-e565-48c7-8988-7d7cf4a8d145" />