### PR TITLE
Removed references to Python Group

### DIFF
--- a/components/Header/Navigation.jsx
+++ b/components/Header/Navigation.jsx
@@ -13,7 +13,6 @@ const navigation = [
     sub_links: [
       { name: 'SWFL Coders', href: 'https://www.meetup.com/swfl-coders/' },
       { name: 'SWFLSec', href: 'https://www.meetup.com/SWFLSec-Southwest-Florida-Infosec-Meetup/' },
-      { name: 'Python SWFL', href: 'https://www.meetup.com/pythonswfl/' },
       { name: 'SWFL Hackerspace', href: 'https://www.meetup.com/swfl-hackerspace/' },
       { name: 'Music Makers SWFL', href: 'https://www.facebook.com/musicmakers.swfl' },
       { name: 'AR & VR SWFL', href: 'https://www.meetup.com/vrarswfl/' },

--- a/components/Logos/Logos.jsx
+++ b/components/Logos/Logos.jsx
@@ -5,7 +5,7 @@ export default function Logos() {
     return(
         <div className="space-y-2 flex flex-col max-h-max max-w-full mb-5 lg:py-6">
           <div className="flex flex-col content-center items-center space-y-4">
-            <div className="grid grid-cols-2 md:grid-cols-3 gap-y-4 gap-x-10 max-w-screen align-center">
+            <div className="grid grid-cols-3 gap-y-4 gap-x-10 max-w-screen justify-items-center">
 
               <Image
                 className="max-w-20 md:max-w-24 lg:max-w-32"
@@ -31,18 +31,11 @@ export default function Logos() {
                 height={500}
               />
 
+           <div className="col-span-3 flex justify-center gap-x-10">
               <Image
                 className="max-w-20 md:max-w-24 lg:max-w-30 rounded-full"
                 src='/images/logos/swfl-coders.png'
                 alt ='SWFL Coders'
-                width={500}
-                height={500}
-              />
-
-              <Image
-                className="max-w-20 md:max-w-24 lg:max-w-32 rounded-full"
-                src='/images/logos/pyswfl.png'
-                alt ='PySWFL'
                 width={500}
                 height={500}
               />
@@ -54,6 +47,7 @@ export default function Logos() {
                 width={500}
                 height={500}
               />
+              </div>
             </div>
           </div>
         </div>

--- a/pages/index.js
+++ b/pages/index.js
@@ -34,7 +34,6 @@ export default function Home() {
               <StaryURL title="Music Makers of SWFL" link="https://www.facebook.com/musicmakers.swfl/" />
               <StaryURL title="VR & AR of Southwest Florida" link="https://www.meetup.com/vrarswfl/" />
               <StaryURL title="SWFL Coders" link="https://www.meetup.com/swfl-coders/" />
-              <StaryURL title="Python SWFL" link="https://www.meetup.com/pythonswfl/" />
               <StaryURL title="SWFL Hackerspace" link="https://www.meetup.com/swfl-hackerspace/" />
             </b>
           </p>

--- a/utils/config.js
+++ b/utils/config.js
@@ -10,16 +10,6 @@ export const groups = [
   },
   {
     id: 2,
-    groupName: 'Python SWFL',
-    groupDescription:
-      'Python SWFL is a volunteer-run interdisciplinary user group for exploration and experimentation with the Python programming language. Whether you are a seasoned software engineer or a complete beginner, all levels are welcome! ',
-    meetingDate: 'Meets the last Tuesday of each month',
-    groupLink: 'https://www.meetup.com/pythonswfl',
-    xLink: 'https://twitter.com/PythonSWFL',
-    linkedinLink: 'https://www.linkedin.com/company/pythonswfl/',
-  },
-  {
-    id: 3,
     groupName: 'SWFL Coders',
     groupDescription:
       'SWFL Coders is a group for techies, developers, coders and non-coders, who wish to learn more about the fantastic world of programming. Our meetings are held twice a month, one at our official home the Collaboratory in Downtown Fort Myers and the other one in Naples or Bonita Springs.',
@@ -31,7 +21,7 @@ export const groups = [
     githubLink: 'https://github.com/swfl-coders',
   },
   {
-    id: 4,
+    id: 3,
     groupName: 'SWFL Hackerspace',
     groupDescription:
       'Hackerspaces are places where tech geeks, experts and nerds meet up to talk, build, and hack technology. Join the Southwest Florida Hackerspace if you feel you can contribute to the group or want to learn more about technology.',
@@ -42,7 +32,7 @@ export const groups = [
     linkedinLink: 'https://www.linkedin.com/company/swfl-hackerspace/',
   },
   {
-    id: 5,
+    id: 4,
     groupName: 'SWFL Sec - Southwest Florida Infosec Meetup',
     groupDescription:
       "The mission of SWFLSec is to provide a free, vendor-neutral forum for the expansion and dissemination of industry knowledge, to extend the culture of security awareness, and enable members to make informed, and educated security decisions. SWFLSec runs on attendee participation. If you've built, broken, or discovered something cool, please consider sharing with the group.",
@@ -54,7 +44,7 @@ export const groups = [
     instagramLink: 'https://www.instagram.com/swflsec/',
   },
   {
-    id: 7,
+    id: 5,
     groupName: 'VR & AR of Southwest Florida',
     groupDescription:
       'Our group welcomes VR/AR creators and enthusiasts of Southwest Florida and beyond! We welcome everyone, including innovators, developers, inventors, storytellers, content producers, entrepreneurs, hackers, programmers, pioneers, and adventurers. Join us to be in touch with ARVR news, events and learn something new to get your development to the next level.',


### PR DESCRIPTION
## Problem

The Python Group left Tech Alliance.

## Solution

Removed all instances/references to the group from the Tech Alliance website.

## Visuals

<img width="1917" height="876" alt="image" src="https://github.com/user-attachments/assets/fe153437-d8ad-4889-9793-11c61e21bbf5" />

### Testing

Manually tested in localhost.

Closes #118 
