### PR TITLE
Added TA code of conduct in the footer as a text link

### DIFF
--- a/components/Footer/Footer.jsx
+++ b/components/Footer/Footer.jsx
@@ -32,6 +32,11 @@ const Footer = () => {
           </a>
         </div>
       </div>
+      <div style={{ textAlign: 'center', marginTop: '20px' }}>
+        <a href="https://docs.google.com/document/d/1yW9A9GLUiE3zwK3voJiZ0Bu18NT8A5a-LxHGb35fi9U/edit?tab=t.0#heading=h.rvqpi9ym5w2c" target="_blank" rel="noreferrer" style={{ color: 'white' }}>
+          Code of Conduct
+        </a>
+      </div>
       <div className={styles.copy}>
         Copyright © <span>{new Date().getFullYear()}</span> Tech Alliance of SWFL. All rights reserved.
       </div>

--- a/components/Footer/Footer.module.css
+++ b/components/Footer/Footer.module.css
@@ -1,6 +1,6 @@
 .footer {
   width: 100%;
-  height: 120px;
+  height: 160px;
   color: white;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Problem

The TA Code of Conduct was not on the website.

## Solution

Added a text-link in the footer that takes the user to code of conduct google doc.

## Visuals

<img width="662" height="231" alt="image" src="https://github.com/user-attachments/assets/3b905214-f740-43d7-9cf7-f1ed719cb7a2" />

### Testing

Placed the text-link in the footer and tested the link by clicking on it and made sure it goes to the google doc.

Closes #104 