### PR TITLE
Add linkedin button footer

### DIFF
--- a/components/Footer/Footer.jsx
+++ b/components/Footer/Footer.jsx
@@ -12,6 +12,16 @@ const Footer = () => {
           </a>
         </div>
         <div className={styles.logos}>
+          <a href="https://www.linkedin.com/company/tech-alliance-of-swfl/" target="_blank" rel="noreferrer">
+            <Image src="/images/socials/li-icon.png" alt="LinkedIn logo" width={40} height={40} />
+          </a>
+        </div>
+        <div className={styles.logos}>
+          <a href="https://discord.gg/G5UR26qAbT" target="_blank" rel="noreferrer">
+            <Image src="/images/socials/dis-icon.png" alt="Discord Logo" width={40} height={40} />
+          </a>
+        </div>
+        <div className={styles.logos}>
           <a href="https://www.facebook.com/techallianceswfl" target="_blank" rel="noreferrer">
             <Image src="/images/socials/fb-icon.png" alt="Facebook logo" width={40} height={40} />
           </a>
@@ -19,11 +29,6 @@ const Footer = () => {
         <div className={styles.logos}>
           <a href="https://twitter.com/tech_swfl" target="_blank" rel="noreferrer">
             <Image src="/images/socials/x-social.png" alt="X/Twitter Logo" width={40} height={40} />
-          </a>
-        </div>
-        <div className={styles.logos}>
-          <a href="https://discord.gg/G5UR26qAbT" target="_blank" rel="noreferrer">
-            <Image src="/images/socials/dis-icon.png" alt="Discord Logo" width={40} height={40} />
           </a>
         </div>
         <div className={styles.logos}>
@@ -45,4 +50,3 @@ const Footer = () => {
 }
 
 export default Footer
-

--- a/components/Footer/Footer.jsx
+++ b/components/Footer/Footer.jsx
@@ -32,6 +32,11 @@ const Footer = () => {
           </a>
         </div>
       </div>
+      <div style={{ textAlign: 'center', marginTop: '20px' }}>
+        <a href="https://docs.google.com/document/d/1yW9A9GLUiE3zwK3voJiZ0Bu18NT8A5a-LxHGb35fi9U/edit?tab=t.0#heading=h.rvqpi9ym5w2c" target="_blank" rel="noreferrer" style={{ color: 'white' }}>
+          Code of Conduct
+        </a>
+      </div>
       <div className={styles.copy}>
         Copyright © <span>{new Date().getFullYear()}</span> Tech Alliance of SWFL. All rights reserved.
       </div>

--- a/components/Footer/Footer.module.css
+++ b/components/Footer/Footer.module.css
@@ -1,6 +1,6 @@
 .footer {
   width: 100%;
-  height: 120px;
+  height: 160px;
   color: white;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Problem

The website's footer is where links to all of TA's social media accounts are located, however there was no link to our LinkedIn account. This is pretty important since we do posts things there including our monthly newsletter.

## Solution

The footer was adjusted to include an image button link to TA's LinkedIn account and the arrangement of the some of the logos was also rearranged so the most used and active accounts are to the left (Meetup, LinkedIn, Discord, and then the rest).

## Visuals

<img width="596" height="227" alt="image" src="https://github.com/user-attachments/assets/010a162e-2ae2-4e78-ac14-be69a456813c" />

##Testing

The new footer was tested on a copy of the website on a local machine before pushing to github to ensure that the link actually works and the layout was changed.

This addresses ticket #116.