### PR TITLE
Updated header buttons

### DIFF
--- a/components/Footer/Footer.jsx
+++ b/components/Footer/Footer.jsx
@@ -12,6 +12,16 @@ const Footer = () => {
           </a>
         </div>
         <div className={styles.logos}>
+          <a href="https://www.linkedin.com/company/tech-alliance-of-swfl/" target="_blank" rel="noreferrer">
+            <Image src="/images/socials/li-icon.png" alt="LinkedIn logo" width={40} height={40} />
+          </a>
+        </div>
+        <div className={styles.logos}>
+          <a href="https://discord.gg/G5UR26qAbT" target="_blank" rel="noreferrer">
+            <Image src="/images/socials/dis-icon.png" alt="Discord Logo" width={40} height={40} />
+          </a>
+        </div>
+        <div className={styles.logos}>
           <a href="https://www.facebook.com/techallianceswfl" target="_blank" rel="noreferrer">
             <Image src="/images/socials/fb-icon.png" alt="Facebook logo" width={40} height={40} />
           </a>
@@ -19,11 +29,6 @@ const Footer = () => {
         <div className={styles.logos}>
           <a href="https://twitter.com/tech_swfl" target="_blank" rel="noreferrer">
             <Image src="/images/socials/x-social.png" alt="X/Twitter Logo" width={40} height={40} />
-          </a>
-        </div>
-        <div className={styles.logos}>
-          <a href="https://discord.gg/G5UR26qAbT" target="_blank" rel="noreferrer">
-            <Image src="/images/socials/dis-icon.png" alt="Discord Logo" width={40} height={40} />
           </a>
         </div>
         <div className={styles.logos}>
@@ -45,4 +50,3 @@ const Footer = () => {
 }
 
 export default Footer
-

--- a/components/Footer/Footer.jsx
+++ b/components/Footer/Footer.jsx
@@ -32,6 +32,11 @@ const Footer = () => {
           </a>
         </div>
       </div>
+      <div style={{ textAlign: 'center', marginTop: '20px' }}>
+        <a href="https://docs.google.com/document/d/1yW9A9GLUiE3zwK3voJiZ0Bu18NT8A5a-LxHGb35fi9U/edit?tab=t.0#heading=h.rvqpi9ym5w2c" target="_blank" rel="noreferrer" style={{ color: 'white' }}>
+          Code of Conduct
+        </a>
+      </div>
       <div className={styles.copy}>
         Copyright © <span>{new Date().getFullYear()}</span> Tech Alliance of SWFL. All rights reserved.
       </div>

--- a/components/Footer/Footer.module.css
+++ b/components/Footer/Footer.module.css
@@ -1,6 +1,6 @@
 .footer {
   width: 100%;
-  height: 120px;
+  height: 160px;
   color: white;
   display: flex;
   flex-direction: column;

--- a/components/Header/Navigation.jsx
+++ b/components/Header/Navigation.jsx
@@ -7,7 +7,7 @@ import Link from 'next/link'
 const navigation = [
   { name: 'Home', href: '/', current: true },
   {
-    name: 'Organizations',
+    name: 'Groups',
     href: '#',
     current: true,
     sub_links: [
@@ -65,17 +65,16 @@ export default function Navigation() {
               </Link>
             </div>
             <div className="hidden sm:ml-6 sm:block">
-              <div className="flex space-x-4">
+              <div className="flex space-x-1">
                 {navigation.map(menuItem => {
-                  return (
-                    <Menu as="div" key={menuItem.name} className="relative ml-3">
+                  return (<Menu as="div" key={menuItem.name} className="relative">
                       <div>
-                        <MenuButton className="rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-700 hover:text-white" {...(menuItem?.sub_links === undefined ? { disabled: true } : {})}>
-                          <a
-                            href={menuItem.href}
-                            className="rounded-md px-3 py-2 text-sm font-medium text-gray-600 hover:text-white">
-                            {menuItem.name}
-                          </a>
+                        <MenuButton   
+                          as={menuItem?.sub_links ? 'button' : 'a'}
+                          href={menuItem?.sub_links ? undefined : menuItem.href}
+                          className="rounded-md px-10 py-2 font-medium text-base text-[#358aca] bg-transparent hover:bg-[#358aca] hover:text-white transition-colors duration-200 flex items-center justify-center"
+                          style={{ fontSize: '22px', fontFamily: 'Roboto, sans-serif' }}>
+                          {menuItem.name}
                         </MenuButton>
                       </div>
                       {menuItem.sub_links && (

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,3 +1,4 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap');
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -19,6 +19,10 @@ module.exports = {
       },
     },
   },
-  plugins: [],
+  plugins: [
+      'text-lg',
+      'text-xl',
+      'font-bold',
+  ],
 }
 


### PR DESCRIPTION
## Problem

The header buttons didn't match the styling of the current website and the figma prototype

## Solution

The buttons were updated to match the styling in the figma prototype. Specifically, the color of words and hover state was changed from gray to blue and the size was increased as well.

## Visuals

<img width="1917" height="311" alt="image" src="https://github.com/user-attachments/assets/a7cb4bdb-6ee1-466a-961d-5a2111f9d9fe" />

### Testing

Changes were made on a test copy of the website on a local machine before pushing to GitHub.

These changes address ticket #119.
